### PR TITLE
Minor patch to ia3.py to prevent unbound error when training model loaded in 8-bit

### DIFF
--- a/src/peft/tuners/ia3.py
+++ b/src/peft/tuners/ia3.py
@@ -548,5 +548,7 @@ if is_bnb_available():
                     if self.is_feedforward:
                         result = super().forward(x * self.ia3_l[self.active_adapter].flatten())
                     else:
+                        if result is None:
+                            result = super().forward(x)
                         result = result * self.ia3_l[self.active_adapter].flatten()
             return result


### PR DESCRIPTION
Fixes an unbound error relating to local variable "result" being referenced prior to being assigned, which arises during fine-tuning using a model loaded in 8-bit, while using Flash Attention (in my case, 2.0.4) and training in BF16 or FP16.

I have no experience nor formal education in computer programming, so apologies if this is redundant. Based on the deductive testing the unbound error was caused by loading a model in 8-bit (using Bitsandbytes 41.0) while training in BF16 or FP16 as required by Flash Attention 2. Adding these two lines fixed the unbound error and did not seem to break anything else. The added text is simply a catch-all for where the code does not execute an if-block which assigns a value to result before reaching the current line 551.